### PR TITLE
Fix posterior_interval

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -48,6 +48,8 @@ posterior_interval.mcmc_fit <- function(object,
                                         prob = 0.9,
                                         pars = c("pi", "theta"),
                                         ...) {
+
+  fit <- object
   K <- fit$data$stan_data$K
   J <- fit$data$stan_data$J
 
@@ -99,8 +101,8 @@ posterior_interval.optim_fit <- function(object,
                                          prob = 0.9,
                                          pars = c("pi", "theta"),
                                          ...) {
-  stop("Can't calculate posterior intervals for a model fit with",
-       "optimisation.",
+  stop("Can't calculate posterior intervals for a model fit using",
+       " optimisation.",
        call. = FALSE)
 }
 

--- a/R/extract.R
+++ b/R/extract.R
@@ -55,7 +55,7 @@ posterior_interval.mcmc_fit <- function(object,
 
   intervals <- list()
   for (i in 1:length(pars)) {
-    par <- match.arg(pars[[i]], c("pi", "theta"))
+    par <- match.arg(pars[[i]], c("pi", "theta", "z"))
 
     if (par == "pi") {
       pi_draws <- posterior_draws(fit, pars = "pi")
@@ -80,8 +80,8 @@ posterior_interval.mcmc_fit <- function(object,
       colnames(theta_draws_mat) <- col_names
       intervals[[i]] <- rstantools::posterior_interval(theta_draws_mat,
                                                        prob, ...)
-    } else if (par == "pi") {
-      stop("Cannot calculate quantiles for pi.", call. = FALSE)
+    } else if (par == "z") {
+      stop("Cannot calculate quantiles for z", call. = FALSE)
     }
   }
 

--- a/tests/testthat/test_extract.R
+++ b/tests/testthat/test_extract.R
@@ -15,6 +15,19 @@ test_that("posterior_draws works", {
   expect_error(posterior_draws(ds_fit, pars = c("nonsense")))
 })
 
+test_that("posterior_interval works", {
+
+  all_intervals <- posterior_interval(ds_fit)
+  expect_type(all_intervals, "double")
+  expect_equal(dim(all_intervals), c(84, 2))
+
+  pi_intervals <- posterior_interval(ds_fit, pars = "pi")
+  expect_equal(dim(pi_intervals), c(4, 2))
+
+  expect_error(posterior_interval(ds_fit, pars = "z"))
+})
+
+
 test_that("point estiamte output is named", {
   all_pars <- point_estimate(ds_fit)
   expect_named(all_pars, c("pi", "theta", "z"))


### PR DESCRIPTION
This addresses https://github.com/jeffreypullin/rater/issues/59#issuecomment-633776717

I don't think we need to define a posterior_interval generic because we are using and importing the generic (and default implementation) for {rstantools}, but perhaps I have missed something. 

As an aside, I'm not certain whether it makes sense to calculate posterior intervals for z. We currently don't.