### PR TITLE
Add a verbose flag to rater

### DIFF
--- a/man/rater.Rd
+++ b/man/rater.Rd
@@ -4,7 +4,15 @@
 \alias{rater}
 \title{Fit statistical models of noisy categorical rating data using Stan}
 \usage{
-rater(data, model, method = "mcmc", data_format = "long", inits = NULL, ...)
+rater(
+  data,
+  model,
+  method = "mcmc",
+  data_format = "long",
+  inits = NULL,
+  verbose = TRUE,
+  ...
+)
 }
 \arguments{
 \item{data}{A 2D data object: data.frame, matrix, tibble etc. with data in
@@ -21,6 +29,9 @@ represents the fitting method used by Stan.}
 The format that the passed data is in. Defaults to "long".}
 
 \item{inits}{The initialization points of the fitting algorithm}
+
+\item{verbose}{Should `rater()` produce information about the progress
+of the chains while using the MCMC algorithm. Defaults to `TRUE`}
 
 \item{...}{Extra parameters which are passed to the Stan fitting interface}
 }

--- a/tests/testthat/test_rater.R
+++ b/tests/testthat/test_rater.R
@@ -1,5 +1,16 @@
 context("rater")
 
+test_that("verbose flag works", {
+
+  expect_message(
+    rater(anesthesia, "dawid_skene",
+          chains = 1, iter = 200, verbose = FALSE),
+    NA
+  )
+
+})
+
+
 test_that("passing model as string works", {
 
   # This was failing previously because the check of whether the model and


### PR DESCRIPTION
This allows users to suppress the chain output while running MCMC. It
will be first put to use in the examples of the package.