### PR TITLE
Improve rater()'s data error messages

### DIFF
--- a/R/inference.R
+++ b/R/inference.R
@@ -364,20 +364,75 @@ validate_data <- function(data, data_format) {
   if (data_format == "long") {
 
     if (!ncol(data) == 3L) {
-      stop("`data` must have exactly three columns.", call. = FALSE)
+      stop("Long format `data` must have exactly three columns.", call. = FALSE)
     }
 
     if (!(all(c("rater", "item", "rating") %in% colnames(data)))) {
-      stop("`data` must have three columns with names: `rater`, `item`, and",
-           " `rating`.", call. = FALSE)
+      stop("Long `data` must have three columns with names: `rater`, `item`,",
+           "and `rating`.", call. = FALSE)
+    }
+
+    # The following are errors about 0 elements. We try to show these errors
+    # all at once to prevent undue frustration.
+    error_messages <- character(0)
+    if (any(data[[1]] == 0)) {
+       error_messages <- c(error_messages, paste0(
+        "Some item indexes are 0. All indexes must be in 1:I",
+        " where I is the number of items."))
+    }
+
+    if (any(data[[2]] == 0)) {
+      error_messages <- c(error_messages, paste0(
+        "Some rater indexes are 0. All indexes must be in 1:J",
+        " where J is the number of raters."))
+    }
+
+    if (any(data[[3]] == 0)) {
+      error_messages <- c(error_messages, paste0(
+        "Some ratings are 0. All ratings must be in 1:K",
+        " where K is the number of classes."))
+    }
+
+    if (length(error_messages) > 0) {
+
+      if (length(error_messages) == 1) {
+        stop(error_messages[[1]], call. = FALSE)
+      } else if (length(error_messages) > 1) {
+        stop("\n", paste0("* ", error_messages, collapse = "\n"), call. = FALSE)
+      }
+
     }
 
   } else if (data_format == "grouped") {
 
     last_col_name <- colnames(data)[[ncol(data)]]
     if (!last_col_name == "n") {
-      stop("The last column must be named `n`.", call = FALSE)
+      stop("The last column must be named `n`.", call. = FALSE)
     }
+
+    error_messages <- character(0)
+    tally <- data$n
+    if (any(tally == 0)) {
+      error_messages <- c(error_messages,
+        "All elements of the column `n` must be > 0."
+      )
+    }
+
+    rest <- data[1:(ncol(data) - 1)]
+    if (any(rest == 0)) {
+      error_messages <- c(error_messages, paste0(
+        "Some ratings are 0. All ratings must be in 1:K",
+        " where K is the number of classes."))
+    }
+
+    if (length(error_messages) == 1) {
+        stop(error_messages[[1]], call. = FALSE)
+    }
+
+    if (length(error_messages) == 2) {
+        stop("\n", paste0("* ", error_messages, collapse = "\n"), call. = FALSE)
+    }
+
   }
 
   data


### PR DESCRIPTION
How do these errors look @dvukcevic?

Fixes #80 

Note that this PR also adds errors for the case of 0 indexing in long data.

``` r
devtools::load_all("/Users/jeffreypullin/Documents/R/rater")
#> Loading rater
#> * The rater package uses `Stan` to fit bayesian models.
#> * If you are working on a local, multicore CPU with excess RAM please call:
#> * options(mc.cores = parallel::detectCores())
#> * This will allow Stan to run inference on multiple cores in parallel.
suppressPackageStartupMessages(library(dplyr))

voxels <- read.csv("~/Downloads/voxels1b.csv")

# Need to fix the logicals.
rater(voxels, "dawid_skene")
#> Error: All columns in `data` must contain only numeric values.

voxels <- voxels %>%
  mutate(across(where(is.logical), as.numeric))

# Need to specify grouped data.
rater(voxels, "dawid_skene")
#> Error: Long format `data` must have exactly three columns.

# Need to rename the last tally column
rater(voxels, "dawid_skene", data_format = "grouped")
#> Error: The last column must be named `n`.

voxels <- voxels %>% 
  rename(n = Freq)

# Can't have tally = 0. 
rater(voxels, "dawid_skene", data_format = "grouped")
#> Error: 
#> * All elements of the column `n` must be > 0.
#> * Some ratings are 0. All ratings must be in 1:K where K is the number of classes.

voxels <- voxels %>%
  filter(n > 0)

# Need to code 1:2 not 0:1
rater(voxels, "dawid_skene", data_format = "grouped")
#> Error: Some ratings are 0. All ratings must be in 1:K where K is the number of classes.

voxels <- voxels %>% 
  mutate(across(1:7, ~ .x + 1))

rater(voxels, "dawid_skene", data_format = "grouped", method = "optim")
#> Bayesian Dawid and Skene Model with MAP estimates.
```

<sup>Created on 2020-07-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>