### PR TITLE
Update the plotting interface

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # rater (development version)
 
+* Plotting via `plot()` of the `rater_fit` object has been changed in several ways. `plot.rater_fit` now:
+
+  - Only returns one plot 
+  - Only returns the theta plot by default
+  - Exposes the `prob`, `which` (called `rater_index`) and new `item_index` 
+    arguments in the plot generic.
+    
+* Add the ability to only plot a subset of items when plotting the class probabilities. This can be controlled by the new `item_index` argument to `plot()`
+
 * Added the function `wide_to_long()` to convert wide data to long data.
 
 * Add the option `data_format = "wide"` to `rater()` to allow wide data to be passed into `rater()` directly.

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -130,7 +130,7 @@ plot_theta <- function(fit, which = NULL) {
 
 #' Plot the latent class estimates of a rater fit.
 #'
-#' @param x numeric matrix object
+#' @param fit A `rater_fit` object.
 #' @param ... Other arguments
 #'
 #' @return Plot of the rate accuracy estimates
@@ -141,22 +141,34 @@ plot_theta <- function(fit, which = NULL) {
 #'
 #' @noRd
 #'
-plot_class_probabilities <- function(fit) {
+plot_class_probabilities <- function(fit, item_index = NULL) {
 
   x <- class_probabilities(fit)
-
-  # We could validate more stringently here if required
-  if (!is.numeric(x)) {
-    stop("Can only plot numeric matrices.", call. = FALSE)
-  }
-
   I <- nrow(x)
   K <- ncol(x)
 
-  plot_data <- data.frame(x = factor(rep(1:K, each = I), levels = 1:K),
-                          y = factor(rep(1:I, K), levels = I:1),
-                          prob = as.vector(x),
-                          round_prob = round(as.vector(x), 2))
+  if (is.null(item_index)) {
+    plot_data <- data.frame(
+      x = factor(rep(1:K, each = I), levels = 1:K),
+      y = factor(rep(1:I, K), levels = I:1),
+      prob = as.vector(x),
+      round_prob = round(as.vector(x), 2)
+    )
+  } else {
+
+    if (!is.numeric(item_index) || !(item_index %in% 1:I)) {
+      stop("`item_index` must be a numeric vector with elements in 1:I",
+           call. = FALSE)
+    }
+
+    x <- x[item_index, ]
+    plot_data <- data.frame(
+      x = factor(rep(1:K, each = length(item_index)), levels = 1:K),
+      y = factor(rep(item_index, K), levels = rev(item_index)),
+      prob = as.vector(x),
+      round_prob = round(as.vector(x), 2)
+    )
+  }
 
   plot <- ggplot2::ggplot(plot_data, ggplot2::aes(x = .data$x, y = .data$y)) +
     ggplot2::geom_tile(ggplot2::aes(fill = .data$prob), colour = "black") +

--- a/man/plot.rater_fit.Rd
+++ b/man/plot.rater_fit.Rd
@@ -4,33 +4,48 @@
 \alias{plot.rater_fit}
 \title{Plot a \code{rater_fit} object}
 \usage{
-\method{plot}{rater_fit}(x, pars = c("pi", "theta", "class_probabilities"), ...)
+\method{plot}{rater_fit}(x, pars = "theta", prob = 0.9, rater_index = NULL, item_index = NULL, ...)
 }
 \arguments{
 \item{x}{An object of class \code{rater_fit}.}
 
-\item{pars}{A character vector of the names of the parameters to plot. By
-default: \code{c("pi", "theta", "class_probabilities")}.}
+\item{pars}{A length one character vector specifying the parameter to plot.
+By default \code{"theta"}.}
 
-\item{...}{Other arguments. This should contain the which argument for
-theta plots.}
+\item{prob}{The coverage of the credible intervals shown in the \code{"pi"} plot.
+If not plotting pi this argument will be ignored. By default \code{0.9}.}
+
+\item{rater_index}{The indexes of the raters shown in the \verb{"theta} plot.
+If not plotting theta this argument will be ignored. By default \code{NULL}
+which means that all raters will be plotted.}
+
+\item{item_index}{The indexes of the items shown in the class probabilities
+plot. If not plotting the class probabilities this argument will be
+ignored. By default \code{NULL} which means that all items will be plotted.
+This argument is particularly useful to focus the subset of items with
+substantial uncertiuanlty in their class assignments.}
+
+\item{...}{Other arguments.}
 }
 \value{
-If one parameter is requested a ggplot2 plot. If multiple parameters
-are requested a list of ggplot2 plots.
+A ggplot2 object.
 }
 \description{
 Plot a \code{rater_fit} object
+}
+\details{
+The use of \code{pars} to refer to only one parameter is for backwards
+compatibility and consistency with the rest of the interface.
 }
 \examples{
 
 \donttest{
 fit <- rater(anesthesia, "dawid_skene")
 
-# Plot all the parameters.
+# By default will just plot the theta plot
 plot(fit)
 
-# Select which parameters to plot.
+# Select which parameter to plot.
 plot(fit, pars = "pi")
 
 }

--- a/tests/testthat/test_fit_class.R
+++ b/tests/testthat/test_fit_class.R
@@ -43,12 +43,6 @@ test_that("plot.fit dispatches correctly", {
 
 })
 
-test_that("can plot multiple parameters", {
-
-  expect_error(plot(ds_fit, pars = c("theta", "pi")), NA)
-
-})
-
 test_that("as_mcmc.list works", {
 
   expect_error(as_mcmc.list(ds_fit_optim))


### PR DESCRIPTION
cc @dvukcevic - your opinion on this change would also be appreciated!

This commit makes several changes. It:

* Makes it only possible to plot one plot at a time (still using the
pars argument)
* Because of this it makes the default plot the theta plot only
* It exposes following existing arguments in the plot generic:
   - `prob` - for controlling the coverage of the credible interval in the pi plot
   -  `which` - (called `rater_index`) for controlling which error matrices to plot 
* It adds a new `item_index` argument allowing the user to select a subset of items to plot the latent class probabilities and exposes it in the generic. 

The main thing I am unhappy with is the fact that `pars` can now only refer to one parameter, though changing this (i.e. to `par`) would break code and make it inconsistent with the rest of the interface. 

Fixes #120 