### PR TITLE
Fix summary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rater (development version)
 
+* `summary()` now works with the class conditional and hierarchical Dawid-Skene models.
+
+* All functions applied to fitted class conditional Dawid-Skene models will automatically convert the relevant parameters of the model into a full theta parameter equivalent to the Dawid-Skene model. This is designed to allow easier comparison of the class conditional model with the full Dawid-Skene model.
+
 * Plotting via `plot()` of the `rater_fit` object has been changed in several ways. `plot.rater_fit` now:
 
   - Only returns one plot 
@@ -18,6 +22,8 @@
 * Added an implementation of the `posterior_predict` generic from {rstantools} allowing simulation from the posterior predictive distribution of fitted standard, and class conditional, Dawid-Skene models. (The hierarchical Dawid-Skene model is not yet supported).
 
 * Added an implementation of the `prior_summary` generic from {rstantools} for `rater_fit` objects.
+
+* Add the `loo.rater_fit` method to allow the calculation of loo, a modern Bayesian model comparison metric, for rater models. loo values can be compared using the excellent {loo} package.
 
 * Added the `loo.rater_fit` method to allow the calculation of loo, a modern Bayesian model comparison metric, for rater models. loo values can be compared using the excellent {loo} package.
 

--- a/R/point_estimate.R
+++ b/R/point_estimate.R
@@ -182,15 +182,13 @@ theta_point_estimate <- function(fit, which = NULL, ...) {
 #' @rdname theta_point_estimate
 #' @noRd
 theta_point_estimate.mcmc_fit <- function(fit, which = NULL, ...) {
-  switch(fit$model$file,
-    "hierarchical_dawid_skene" = theta_point_estimate_hds(),
-    "dawid_skene" = theta_point_estimate_ds_mcmc(fit, which, ...),
-    "class_conditional_dawid_skene" =
-      theta_point_estimate_ccds_mcmc(fit, which, ...),
-    stop("Model type not supported", call. = FALSE))
-}
 
-theta_point_estimate_ds_mcmc <- function(fit, which, ...) {
+  if (inherits(fit$model, "hier_dawid_skene")) {
+    theta_point_estimate_hds()
+  }
+
+  # We now 'unspool' the theta parameter for the class conditional model by
+  # default so this works for both the standard and class conditional models.
   theta_samps <- posterior_samples(fit, pars = "theta")[[1]]
 
   J <- dim(theta_samps)[[2]]
@@ -200,20 +198,6 @@ theta_point_estimate_ds_mcmc <- function(fit, which, ...) {
   validate_which(which, J)
 
   theta <- apply(theta_samps, c(2, 3, 4), mean)
-  theta[which, , ]
-}
-
-theta_point_estimate_ccds_mcmc <- function(fit, which, ...) {
-  cc_theta_samps <- posterior_samples(fit, pars = "theta")[[1]]
-
-  J <- dim(cc_theta_samps)[[2]]
-  if (is.null(which)) {
-    which <- 1:J
-  }
-  validate_which(which, J)
-
-  cc_theta <- apply(cc_theta_samps, c(2, 3), mean)
-  theta <- unspool_cc_theta(cc_theta)
   theta[which, , ]
 }
 

--- a/R/point_estimate.R
+++ b/R/point_estimate.R
@@ -74,7 +74,9 @@ pi_point_estimate.mcmc_fit <- function(fit, ...) {
 #' @noRd
 pi_point_estimate.optim_fit <- function(fit, ...) {
   par <- fit$estimates$par
-  out <- par[grep("pi", names(par))]
+  # ^ is an anchor for the start of the line - needed due to the log_pi in the
+  # HDS model.
+  out <- par[grep("^pi", names(par))]
   names(out) <- NULL
   out
 }

--- a/R/point_estimate.R
+++ b/R/point_estimate.R
@@ -238,8 +238,8 @@ theta_point_estimate_ccds_optim <- function(fit, which, ...) {
 }
 
 theta_point_estimate_hds <- function() {
-  stop("Rater metrics cannot be extracted from the Hierachical Dawid and
-       Skene model.", call. = FALSE)
+  stop("theta cannot be extracted from the Hierachical Dawid-Skene model.",
+       "\nConsider using `pars = c('pi', 'z')`.", call. = FALSE)
 }
 
 # Helper functions

--- a/R/point_estimate.R
+++ b/R/point_estimate.R
@@ -11,6 +11,11 @@
 #'   value of class probabilities which is largest. To return the full
 #'   posterior distributions of the latent class use `class_probabilities()`.
 #'
+#'   For the class conditional model the 'full' theta parameterisation (i.e.
+#'   appearing to have the same number of parameters as the standard
+#'   Dawid-Skene model) is calculated and returned. This is designed to allow
+#'   easier comparison with the full Dawid-Skene model.
+#'
 #' @return A named list of the parameter estimates.
 #'
 #' @seealso `class_probabilities()`

--- a/R/posterior_interval.R
+++ b/R/posterior_interval.R
@@ -59,13 +59,15 @@ posterior_interval.mcmc_fit <- function(object,
 
       theta_draws_mat <- matrix(0, nrow = n_draws, ncol = J * K * K)
       col_names <- character(J * K * K)
-      combs <- expand.grid(1:J, 1:K, 1:K)
-      for (n in 1:nrow(combs)) {
-        j <- combs[n, 1]
-        k <- combs[n, 2]
-        k_prime <- combs[n, 3]
-        theta_draws_mat[, n] <- theta_draws_raw[, j, k, k_prime]
-        col_names[[n]] <- sprintf("theta[%s, %s, %s]", j, k, k_prime)
+      n <- 1
+      for (j in 1:J) {
+        for (k in 1:K) {
+          for (i in 1:K) {
+            theta_draws_mat[, n] <- theta_draws_raw[, j, k, i]
+            col_names[[n]] <- sprintf("theta[%s, %s, %s]", j, k, i)
+            n <- n + 1
+          }
+        }
       }
       colnames(theta_draws_mat) <- col_names
       intervals[[i]] <- rstantools::posterior_interval(theta_draws_mat,

--- a/R/posterior_interval.R
+++ b/R/posterior_interval.R
@@ -16,6 +16,11 @@
 #'   class (and indeed cannot be calculated). The *full* posterior distribution
 #'   of the latent class can be extracted using [class_probabilities]
 #'
+#'   For the class conditional model the 'full' theta parameterisation (i.e.
+#'   appearing to have the same number of parameters as the standard
+#'   Dawid-Skene model) is calculated and returned. This is designed to allow
+#'   easier comparison with the full Dawid-Skene model.
+#'
 #' @examples
 #'
 #' \donttest{

--- a/R/posterior_samples.R
+++ b/R/posterior_samples.R
@@ -48,6 +48,11 @@ posterior_samples <- function(fit, pars = c("pi", "theta")) {
     samples <- switch(par,
       "pi"    = c(samples, pi = list(rstan::extract(get_samples(fit))$pi)),
       "theta" = {
+        if (inherits(fit$model, "hier_dawid_skene")) {
+          # HACK to get consistent error message.
+          theta_point_estimate_hds()
+        }
+
         raw_theta <- rstan::extract(get_samples(fit))$theta
         if (inherits(fit$model, "class_conditional_dawid_skene")) {
           N <- dim(raw_theta)[[1]]

--- a/R/posterior_samples.R
+++ b/R/posterior_samples.R
@@ -43,7 +43,21 @@ posterior_samples <- function(fit, pars = c("pi", "theta")) {
     par <- match.arg(par, c("pi", "theta", "z"))
     samples <- switch(par,
       "pi"    = c(samples, pi = list(rstan::extract(get_samples(fit))$pi)),
-      "theta" = c(samples, theta = list(rstan::extract(get_samples(fit))$theta)),
+      "theta" = {
+        raw_theta <- rstan::extract(get_samples(fit))$theta
+        if (inherits(fit$model, "class_conditional_dawid_skene")) {
+          N <- dim(raw_theta)[[1]]
+          J <- fit$stan_data$J
+          K <- fit$stan_data$K
+          full_theta <- array(dim = c(N, J, K, K))
+          for (i in seq_len(N)) {
+            full_theta[i, , , ] <- unspool_cc_theta(raw_theta[i, , ])
+          }
+        } else {
+          full_theta <- raw_theta
+        }
+        c(samples, theta = list(full_theta))
+      },
       "z"     = stop("Cannot return draws for marginalised discrete parameter",
                      call. = FALSE),
       stop("Invalid pars argument", call. = FALSE)

--- a/R/posterior_samples.R
+++ b/R/posterior_samples.R
@@ -11,9 +11,10 @@
 #'   MCMC not optimisation. In addition, posterior samples cannot be returned
 #'   for the latent class due to the marginalisation technique used internally.
 #'
-#'   By default for the class conditional model the 'full' theta
-#'   parameterisation (i.e. appearing to have the same number of parameters as
-#'   the standard Dawid-Skene model) is returned.
+#'   For the class conditional model the 'full' theta parameterisation (i.e.
+#'   appearing to have the same number of parameters as the standard
+#'   Dawid-Skene model) is calculated and returned. This is designed to allow
+#'   easier comparison with the full Dawid-Skene model.
 #'
 #' @importFrom rstan extract
 #'

--- a/R/posterior_samples.R
+++ b/R/posterior_samples.R
@@ -11,6 +11,10 @@
 #'   MCMC not optimisation. In addition, posterior samples cannot be returned
 #'   for the latent class due to the marginalisation technique used internally.
 #'
+#'   By default for the class conditional model the 'full' theta
+#'   parameterisation (i.e. appearing to have the same number of parameters as
+#'   the standard Dawid-Skene model) is returned.
+#'
 #' @importFrom rstan extract
 #'
 #' @examples

--- a/R/rater_fit_class.R
+++ b/R/rater_fit_class.R
@@ -140,6 +140,11 @@ plot.rater_fit <- function(x,
 #' @param n_pars The number of pi/theta parameters and z 'items' to display.
 #' @param ... Other arguments passed to function.
 #'
+#' @details For the class conditional model the 'full' theta parameterisation
+#'   (i.e. appearing to have the same number of parameters as the standard
+#'   Dawid-Skene model) is calculated and returned. This is designed to allow
+#'   easier comparison with the full Dawid-Skene model.
+#'
 #' @method summary mcmc_fit
 #'
 #' @importFrom utils head
@@ -203,6 +208,11 @@ summary.mcmc_fit <- function(object, n_pars = 8, ...) {
 #' @param object An object of class `optim_fit`.
 #' @param n_pars The number of pi/theta parameters and z 'items' to display.
 #' @param ... Other arguments passed to function.
+#'
+#' @details For the class conditional model the 'full' theta parameterisation
+#'   (i.e. appearing to have the same number of parameters as the standard
+#'   Dawid-Skene model) is calculated and returned. This is designed to allow
+#'   easier comparison with the full Dawid-Skene model.
 #'
 #' @method summary optim_fit
 #'

--- a/R/rater_fit_class.R
+++ b/R/rater_fit_class.R
@@ -156,14 +156,18 @@ summary.mcmc_fit <- function(object, n_pars = 8, ...) {
   pi_mcmc_diagnostics <- mcmc_diagnostics(fit, pars = "pi")
   pi <- cbind(pi_est, pi_interval, pi_mcmc_diagnostics)
 
-  # Prepare theta.
-  theta_est <- theta_to_long_format(theta_point_estimate(fit))
-  colnames(theta_est) <- "mean"
-  theta_interval <- posterior_interval(fit, pars = "theta")
-  theta_mcmc_diagnostics <- mcmc_diagnostics(fit, pars = "theta")
-  theta <- cbind(theta_est, theta_interval, theta_mcmc_diagnostics)
+  pars <- pi
 
-  pars <- rbind(pi, theta)
+  if (!inherits(get_model(fit), "hier_dawid_skene")) {
+    # Prepare theta.
+    theta_est <- theta_to_long_format(theta_point_estimate(fit))
+    colnames(theta_est) <- "mean"
+    theta_interval <- posterior_interval(fit, pars = "theta")
+    theta_mcmc_diagnostics <- mcmc_diagnostics(fit, pars = "theta")
+    theta <- cbind(theta_est, theta_interval, theta_mcmc_diagnostics)
+
+    pars <- rbind(pi, theta)
+  }
 
   # Prepare z.
   class_probs <- class_probabilities(fit)
@@ -181,9 +185,11 @@ summary.mcmc_fit <- function(object, n_pars = 8, ...) {
 
   cat("\npi/theta samples:\n")
   print(round(utils::head(pars, n_pars), 2))
-  # pars is a matrix where each row is a parameter.
-  n_remaining <- nrow(pars) - n_pars
-  cat("# ... with", n_remaining, "more parameters\n")
+  # pars is a matrix where each row is a parametery thing.
+  if (nrow(pars) > n_pars) {
+    n_remaining <- nrow(pars) - n_pars
+    cat("# ... with", n_remaining, "more rows\n")
+  }
 
   cat("\nz:\n")
   print(round(head(z_out, n_pars), 2))
@@ -212,11 +218,14 @@ summary.optim_fit <- function(object, n_pars = 8, ...) {
   pi <- pi_to_long_format(pi_point_estimate(fit))
   colnames(pi) <- "mean"
 
-  # Prepare theta.
-  theta <- theta_to_long_format(theta_point_estimate(fit))
-  colnames(theta) <- "mean"
+  pars <- pi
 
-  pars <- rbind(pi, theta)
+  # Prepare theta.
+  if (!inherits(get_model(fit), "hier_dawid_skene")) {
+    theta <- theta_to_long_format(theta_point_estimate(fit))
+    colnames(theta) <- "mean"
+    pars <- rbind(pi, theta)
+  }
 
   # Prepare z.
   class_probs <- class_probabilities(fit)
@@ -233,10 +242,13 @@ summary.optim_fit <- function(object, n_pars = 8, ...) {
   cat("\nFitting method: Optimisation\n")
 
   cat("\npi/theta estimates:\n")
+
   print(round(head(pars, n_pars), 2))
   # pars is a *list*
-  n_remaining <- length(pars) - n_pars
-  cat("# ... with", n_remaining, "more parameters\n")
+  if (length(pars) > n_pars) {
+    n_remaining <- length(pars) - n_pars
+    cat("# ... with", n_remaining, "more rows\n")
+  }
 
   cat("\nz:\n")
   print(round(utils::head(z_out, n_pars), 2))

--- a/man/point_estimate.Rd
+++ b/man/point_estimate.Rd
@@ -26,6 +26,11 @@ means are returned. If it was fit through optimisation the maximum a
 priori (MAP) estimates are returned. The z parameter returned is the
 value of class probabilities which is largest. To return the full
 posterior distributions of the latent class use \code{class_probabilities()}.
+
+For the class conditional model the 'full' theta parameterisation (i.e.
+appearing to have the same number of parameters as the standard
+Dawid-Skene model) is calculated and returned. This is designed to allow
+easier comparison with the full Dawid-Skene model.
 }
 \examples{
 

--- a/man/posterior_interval.mcmc_fit.Rd
+++ b/man/posterior_interval.mcmc_fit.Rd
@@ -31,6 +31,11 @@ Posterior intervals can only be calculated for models fit with
 MCMC. In addition, posterior intervals are not meaningful for the latent
 class (and indeed cannot be calculated). The \emph{full} posterior distribution
 of the latent class can be extracted using \link{class_probabilities}
+
+For the class conditional model the 'full' theta parameterisation (i.e.
+appearing to have the same number of parameters as the standard
+Dawid-Skene model) is calculated and returned. This is designed to allow
+easier comparison with the full Dawid-Skene model.
 }
 \examples{
 

--- a/man/posterior_samples.Rd
+++ b/man/posterior_samples.Rd
@@ -23,6 +23,10 @@ Extract posterior samples from a rater fit object
 Posterior samples can only be returned for models fitting using
 MCMC not optimisation. In addition, posterior samples cannot be returned
 for the latent class due to the marginalisation technique used internally.
+
+By default for the class conditional model the 'full' theta
+parameterisation (i.e. appearing to have the same number of parameters as
+the standard Dawid-Skene model) is returned.
 }
 \examples{
 

--- a/man/posterior_samples.Rd
+++ b/man/posterior_samples.Rd
@@ -24,9 +24,10 @@ Posterior samples can only be returned for models fitting using
 MCMC not optimisation. In addition, posterior samples cannot be returned
 for the latent class due to the marginalisation technique used internally.
 
-By default for the class conditional model the 'full' theta
-parameterisation (i.e. appearing to have the same number of parameters as
-the standard Dawid-Skene model) is returned.
+For the class conditional model the 'full' theta parameterisation (i.e.
+appearing to have the same number of parameters as the standard
+Dawid-Skene model) is calculated and returned. This is designed to allow
+easier comparison with the full Dawid-Skene model.
 }
 \examples{
 

--- a/man/summary.mcmc_fit.Rd
+++ b/man/summary.mcmc_fit.Rd
@@ -16,3 +16,9 @@
 \description{
 Summarise a \code{mcmc_fit} object
 }
+\details{
+For the class conditional model the 'full' theta parameterisation
+(i.e. appearing to have the same number of parameters as the standard
+Dawid-Skene model) is calculated and returned. This is designed to allow
+easier comparison with the full Dawid-Skene model.
+}

--- a/man/summary.optim_fit.Rd
+++ b/man/summary.optim_fit.Rd
@@ -16,3 +16,9 @@
 \description{
 Summarise an \code{optim_fit} object
 }
+\details{
+For the class conditional model the 'full' theta parameterisation
+(i.e. appearing to have the same number of parameters as the standard
+Dawid-Skene model) is calculated and returned. This is designed to allow
+easier comparison with the full Dawid-Skene model.
+}

--- a/tests/testthat/test-mcmc_diagnostics.R
+++ b/tests/testthat/test-mcmc_diagnostics.R
@@ -12,4 +12,6 @@ test_that("mcmc_diagnostics works", {
 
   expect_error(mcmc_diagnostics(ds_fit_optim))
   expect_error(mcmc_diagnostics(ds_fit, pars = "z"))
+
+  expect_error(mcmc_diagnostics(ccds_fit), NA)
 })

--- a/tests/testthat/test-posterior_interval.R
+++ b/tests/testthat/test-posterior_interval.R
@@ -9,3 +9,11 @@ test_that("posterior_interval works", {
 
   expect_error(posterior_interval(ds_fit, pars = "z"))
 })
+
+test_that("posterior_interval orders parameters correctly", {
+
+  correct_rownames <- sprintf("theta[1, 1, %s]", 1:K)
+  expect_equal(rownames(posterior_interval(ds_fit, pars = "theta"))[1:K],
+               correct_rownames)
+
+})

--- a/tests/testthat/test-posterior_samples.R
+++ b/tests/testthat/test-posterior_samples.R
@@ -8,6 +8,13 @@ test_that("posterior_samples works", {
   # We error if the user requests draws from z
   expect_error(posterior_samples(ds_fit, pars = c("z")))
 
-  # Or if they pass an invalid pararmaeter
+  # Or if they pass an invalid parameter
   expect_error(posterior_samples(ds_fit, pars = c("nonsense")))
+})
+
+test_that("posterior_samples returns full theta for class conditional model", {
+
+  # 100 is the number of post-warmup samples in the tests.
+  expect_equal(dim(posterior_samples(ccds_fit)$theta), c(100, J, K, K))
+
 })

--- a/tests/testthat/test_fit_class.R
+++ b/tests/testthat/test_fit_class.R
@@ -60,3 +60,14 @@ test_that("get_stanfit works", {
   expect_equal(get_stanfit(ds_fit_optim), ds_fit_optim$estimates)
   expect_error(get_stanfit(2))
 })
+
+test_that("summary works", {
+
+  expect_error(summary(ds_fit), NA)
+  expect_error(summary(ds_fit_optim), NA)
+  expect_error(summary(ds_fit_grouped, NA))
+
+  expect_error(summary(ccds_fit), NA)
+  expect_error(summary(hds_fit), NA)
+
+})


### PR DESCRIPTION
cc @dvukcevic - I would love a second opinion on this - when you get a chance of course.

This PR was motivated by the (somewhat embarrassing) realization that our `summary()` function did not work for the class conditional or hierarchical Dawid-Skene model. This PR fixes this but in doing so made some other major changes.

In particular I realized there was a large inconsistency with how `point_estimate()`, `posterior_interval()` and `posterior_samples()` interacted with the theta parameter in the class conditional model.

At some point in the past I had decided that for the CC model `point_estimate()` would return the full theta array (i.e. the same number of parameters as in the full DS model) calculated from it's own J by K theta parameter. I made this decision so that plotting theta for the class conditional model would work and be directly comparable to the full DS model. (With the idea that the CC model would generally be fit after and then compared to the full DS model). 

At the time `posterior_samples()` and `posterior_interval()` were implemented however I had forgotten about the behavior of `point_estimate()` so `posterior_samples()` only returned the actual 'reduced' theta parameter of the CC model and this caused problems in `posterior_interval()` which was (one of) the problems in the summary method...

(NB: We don't support returning the theta parameter from the hierarchical DS model at all because it can't be interpreted in the same way as the full and CC DS model)

To get around this problem I decided the easiest thing to do was to simply ALWAYS convert the theta parameter in the CC model to the full DS form (and that is what is implemented in this PR). This ensures consistenty across all functions in the interface from `point_estimate()` to `mcmc_diagnostics()`. I think this the best approach but I'd appreciate your opinion on it!

Advantages:

* Easier for users to compare the CC and full DS
* Simplest implementation by far (full and CC methods can have identical code to deal with theta),

Disadvantages:

* May confuse the user about what the CC model is and how it differs from the full DS model. 

It's important to note the 'true' parameters of the CC model can easily be extract from all the returned functions.

Fixes #133 + a lot more besides