### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     Rcpp (>= 0.12.0),
     RcppParallel (>= 5.0.1),
     rlang (> 0.2.0),
-    rstan (>= 2.19.2),
+    rstan (>= 2.26.0),
     rstantools (>= 2.0.0)
 Suggests:
     coda,
@@ -46,8 +46,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 VignetteBuilder: 
     knitr
 Biarch: true

--- a/inst/stan/class_conditional_dawid_skene.stan
+++ b/inst/stan/class_conditional_dawid_skene.stan
@@ -3,9 +3,9 @@ data {
   int<lower=1> J;               // number of annotators
   int<lower=1> K;               // number of annotation categories
   int<lower=1> I;               // number of items
-  int<lower=1, upper=I> ii[N];  // item index for annotation n
-  int<lower=1, upper=J> jj[N];  // annotator for annotation n
-  int<lower=0, upper=K> y[N];   // annotation for observation n
+  array[N] int<lower=1, upper=I> ii;  // item index for annotation n
+  array[N] int<lower=1, upper=J> jj;  // annotator for annotation n
+  array[N] int<lower=0, upper=K> y;   // annotation for observation n
   vector<lower=0>[K] alpha;     // prior for pi
   // Assume the same across raters
   vector<lower=0>[K] beta_1;    // prior for theta
@@ -18,7 +18,7 @@ parameters {
 }
 
 transformed parameters {
-  vector[K] log_p_z[I];
+  array[I] vector[K] log_p_z;
 
   for (i in 1:I) {
     log_p_z[i] = log(pi);

--- a/inst/stan/dawid_skene.stan
+++ b/inst/stan/dawid_skene.stan
@@ -13,20 +13,20 @@ data {
   int<lower=1> J;               // number of annotators
   int<lower=1> K;               // number of annotation categories
   int<lower=1> I;               // number of items
-  int<lower=1, upper=I> ii[N];  // item index for annotation n
-  int<lower=1, upper=J> jj[N];  // annotator for annotation n
-  int<lower=0, upper=K> y[N];   // annotation for observation n
+  array[N] int<lower=1, upper=I> ii;  // item index for annotation n
+  array[N] int<lower=1, upper=J> jj;  // annotator for annotation n
+  array[N] int<lower=0, upper=K> y;   // annotation for observation n
   vector<lower=0>[K] alpha;     // prior for pi
-  vector<lower=0>[K] beta[J, K];   // prior for theta
+  array[J, K] vector<lower=0>[K] beta;   // prior for theta
 }
 
 parameters {
   simplex[K] pi;
-  simplex[K] theta[J, K];
+  array[J, K] simplex[K] theta;
 }
 
 transformed parameters {
-  vector[K] log_p_z[I];
+  array[I] vector[K] log_p_z;
   for (i in 1:I) {
     log_p_z[i] = log(pi);
   }

--- a/inst/stan/grouped_data.stan
+++ b/inst/stan/grouped_data.stan
@@ -2,19 +2,19 @@ data {
   int<lower=1> N;                  // number of different amounts
   int<lower=1> K;                  // number of annotation categories
   int<lower=1> J;                  // number of annotators
-  real tally[N];                   // total of each different combination
-  int<lower=1,upper=K> key[N, J];  //
+  array[N] real tally;                   // total of each different combination
+  array[N, J] int<lower=1,upper=K> key;  //
   vector<lower=0>[K] alpha;        // prior for pi
-  vector<lower=0>[K] beta[J, K];   // prior for theta
+  array[J, K] vector<lower=0>[K] beta;   // prior for theta
 }
 
 parameters {
   simplex[K] pi;
-  simplex[K] theta[J, K];
+  array[J, K] simplex[K] theta;
 }
 
 transformed parameters {
-  vector[K] log_p_z[N];
+  array[N] vector[K] log_p_z;
   // use the prior for the prevalence
   for (i in 1:N) {
     log_p_z[i] = log(pi);

--- a/inst/stan/hierarchical_dawid_skene.stan
+++ b/inst/stan/hierarchical_dawid_skene.stan
@@ -3,22 +3,22 @@ data {
   int<lower=1> J;               // Number of raters.
   int<lower=1> K;               // Number of rating categories.
   int<lower=1> I;               // Number of items.
-  int<lower=1, upper=I> ii[N];  // Item index for rating n.
-  int<lower=1, upper=J> jj[N];  // Rater for annotation n.
-  int<lower=0, upper=K> y[N];   // Rating for observation n.
+  array[N] int<lower=1, upper=I> ii;  // Item index for rating n.
+  array[N] int<lower=1, upper=J> jj;  // Rater for annotation n.
+  array[N] int<lower=0, upper=K> y;   // Rating for observation n.
   vector<lower=0>[K] alpha;     // Prior on pi.
 }
 
 parameters {
   simplex[K] pi;
-  matrix[K, K] beta_raw[J];
+  array[J] matrix[K, K] beta_raw;
   matrix[K, K] mu;
   matrix<lower=0>[K, K] sigma;
 }
 
 transformed parameters {
-  matrix[K,K] beta[J];
-  vector[K] log_p_z[I];
+  array[J] matrix[K,K] beta;
+  array[I] vector[K] log_p_z;
   vector[K] log_pi;
 
   for(j in 1:J) {


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
